### PR TITLE
Device name offset

### DIFF
--- a/snaptastic/ebs_volume.py
+++ b/snaptastic/ebs_volume.py
@@ -46,7 +46,7 @@ class EBSVolume(object):
 
     def __init__(self, device, mount_point, size=5, delete_on_termination=True,
                  file_system=FILESYSTEMS.XFS, mount_options="defaults",
-                 check_support=True, iops=False):
+                 check_support=True, iops=False, device_name_offset=None):
         self.device = device
         self.size = size
         self.mount_point = mount_point
@@ -54,6 +54,7 @@ class EBSVolume(object):
         self.delete_on_termination = delete_on_termination
         self.file_system = file_system
         self.iops = iops
+        self.device_name_offset = device_name_offset
         if check_support:
             self.ensure_filesytem_supported()
 

--- a/snaptastic/ebs_volume.py
+++ b/snaptastic/ebs_volume.py
@@ -81,9 +81,25 @@ class EBSVolume(object):
     @property
     def instance_device(self):
         '''
-        Ubuntu places the device under /dev/sdf in /dev/xvdf
+        EC2 places the device under /dev/sdf in /dev/xvdf.
+        
+        Some AMIs before further translation of the requested and actual
+        device name. e.g. the CentOS AMI will attach /dev/sdj if you request
+        /dev/sdf. Fortunately this offset is consistent. Use the device_name_offset
+        parameter to control this:
+            
+        volume = EBSVolume('/dev/sdf', '/mnt/somedir', size=20, device_name_offset=4)
+
+        This would result in a device named /dev/sdj.
+
         '''
         device = self.device.replace('sd', 'xvd')
+
+
+        if self.device_name_offset != 0:
+            # If the offset is 4, change e.g. sdf -> sdj
+            device = device[:-1] + chr(ord(device[-1]) + self.device_name_offset)
+
         return device
 
     def mount(self):

--- a/snaptastic/snapshotter.py
+++ b/snaptastic/snapshotter.py
@@ -420,7 +420,7 @@ class Snapshotter(object):
         return latest_snapshot
 
     # Example, Redis.goteam.be snapshot of /mnt/persistent/
-    SNAPSHOT_DESCRIPTION_FORMAT = "%(cluster)s snapshot of %(mount_point)s"
+    SNAPSHOT_DESCRIPTION_FORMAT = "Snapshot of %(mount_point)s"
 
     def get_snapshot_description(self, vol):
         format_dict = dict(

--- a/snaptastic/snapshotter.py
+++ b/snaptastic/snapshotter.py
@@ -192,7 +192,7 @@ class Snapshotter(object):
                 self.mount_snapshot(vol)
             except exceptions.DeviceAlreadyExists:
                 if ignore_mounted:
-                    logger.info("Ignoring {}".format(vol))
+                    logger.info("Ignoring {0}".format(vol))
                 else:
                     raise
 

--- a/snaptastic/snapshotter.py
+++ b/snaptastic/snapshotter.py
@@ -419,15 +419,16 @@ class Snapshotter(object):
             raise exceptions.MissingSnapshot(e.message)
         return latest_snapshot
 
-    # Example, Redis.goteam.be snapshot of /mnt/persistent/
-    SNAPSHOT_DESCRIPTION_FORMAT = "Snapshot of %(mount_point)s"
+    def get_snapshot_description_string(self):
+         # Example, Redis.goteam.be snapshot of /mnt/persistent/
+        return "%(cluster)s snapshot of %(mount_points)s"
 
     def get_snapshot_description(self, vol):
         format_dict = dict(
             mount_point=vol.mount_point
         )
         format_dict.update(self.userdata)
-        snapshot_name = self.SNAPSHOT_DESCRIPTION_FORMAT % format_dict
+        snapshot_name = self.get_snapshot_description_string() % format_dict
         snapshot_name = snapshot_name.replace('_', '-')
         return snapshot_name
 


### PR DESCRIPTION
A few fixes here:
- fixed a formatting error when using --ignore-mounted
- removed %(cluster)s from formatting string - it's not required, so should not be relied upon here
- added option to offset device name, for AMIs that mount volumes with a different device name from that which was requested (e.g. you request sdf, CentOS creates the device at sdj)
